### PR TITLE
JANITORIAL: fixed a few compiler warnings and pass by value for some …

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This repository serves as a simple example project for the algorithm.
 
 Demo of a larger world: https://www.youtube.com/watch?v=LxfDmF0HxSg
 
-**UPDATE: 2024-04-19:**  
+**UPDATE: 2024-04-19:**
 **The ambient occlusion implementation was fixed - it should look better now.**
 
-**UPDATE: 2024-04-21:**  
+**UPDATE: 2024-04-21:**
 **Optimized the code to be up to 25% faster.**
 
-**UPDATE: 2024-04-25:**  
+**UPDATE: 2024-04-25:**
 **Optimized the code to be up to 15% faster and allocate less memory on every run.**
 
 ## Setup example (Visual Studio)
@@ -37,18 +37,18 @@ Meshing duration is printed to the console.
 ## How to use the mesher
 The main implementation is in src/mesher.h
 
-### Input data:  
-**- std::vector<uint8_t>& voxels**  
-&nbsp;&nbsp;&nbsp;&nbsp; - The input data includes duplicate edge data from neighboring chunks which is used for visibility culling and AO. For optimal performance, your world data should already be structured this way so that you can feed the data straight into this algorithm.  
-&nbsp;&nbsp;&nbsp;&nbsp; - Input data is ordered in YXZ and is 64^3 which results in a 62^3 mesh. 
+### Input data:
+**- std::vector<uint8_t>& voxels**
+&nbsp;&nbsp;&nbsp;&nbsp; - The input data includes duplicate edge data from neighboring chunks which is used for visibility culling and AO. For optimal performance, your world data should already be structured this way so that you can feed the data straight into this algorithm.
+&nbsp;&nbsp;&nbsp;&nbsp; - Input data is ordered in YXZ and is 64^3 which results in a 62^3 mesh.
 
-**- MeshData& meshData**  
-&nbsp;&nbsp;&nbsp;&nbsp; - Data that needs to be allocated once (per thread if meshing with multiple threads)  
+**- MeshData& meshData**
+&nbsp;&nbsp;&nbsp;&nbsp; - Data that needs to be allocated once (per thread if meshing with multiple threads)
 
-**- bool bake_ao**  
-&nbsp;&nbsp;&nbsp;&nbsp; - true if you want baked ambient occlusion.  
+**- bool bake_ao**
+&nbsp;&nbsp;&nbsp;&nbsp; - true if you want baked ambient occlusion.
 
-### Output data:  
+### Output data:
 &nbsp;&nbsp;&nbsp;&nbsp; - The allocated vertices in MeshData with a length of meshData.vertexCount.
 
 ## Mesh details
@@ -75,19 +75,19 @@ Average execution time (1000+ runs)
 | Scene                  | Ryzen 7 3800x (Windows)      | Ryzen 7 5800h (Linux) | Ryzen 3950x (Windows) |
 |:-----------------------|:-----------------------------|-----------------------|-----------------------|
 | 3d hills (AO)          | 552us / 43021 verts          | 502us                 | 615ms
-| 3d hills (No AO)       | 325us / 24751 verts          | 
+| 3d hills (No AO)       | 325us / 24751 verts          |
 | Red sphere (AO)        | 656us / 71533 verts          | 592us
 | Red sphere (No AO)     | 317us / 43201 verts          |
 | Empty (AO)             | 148us / 0 verts              | 221us
 | Empty (No AO)          | 125us / 0 verts              |
 | White noise (AO)       | 10.211ms / 1594069 verts     | 7.509ms
-| White noise (No AO)    | 3.545ms / 1415419 verts      | 
+| White noise (No AO)    | 3.545ms / 1415419 verts      |
 | Checkerboard (AO)      | 11.696ms / 4289904 verts     | 8.154ms
 | Checkerboard (No AO)   | 6.271ms / 4289904 verts      |
 
 ## Other resources
 ### Meshing in a minecraft game:
-https://0fps.net/2012/06/30/meshing-in-a-minecraft-game/  
+https://0fps.net/2012/06/30/meshing-in-a-minecraft-game/
 
 ### Ambient occlusion for Minecraft-like worlds
 https://0fps.net/2013/07/03/ambient-occlusion-for-minecraft-like-worlds/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,13 +2,12 @@
 #include <GLFW/glfw3.h>
 
 #include <glad/glad.h>
-#include <iostream>
-#include <vector>
 #include <algorithm>
 #include "misc/shader.h"
 #include "misc/camera.h"
 #include "misc/noise.h"
 #include "misc/utility.h"
+#include "misc/timer.h"
 
 #include "mesher.h"
 

--- a/src/mesher.h
+++ b/src/mesher.h
@@ -1,4 +1,4 @@
-/* 
+/*
 MIT License
 
 Copyright (c) 2020 Erik Johansson
@@ -25,27 +25,25 @@ SOFTWARE.
 #ifndef MESHER_H
 #define MESHER_H
 
-#include <glad/glad.h>
 #include <glm/glm.hpp>
 #include <vector>
 #include <stdint.h>
-#include <string.h>
+#include <string.h> // memset
 
-#include "misc/timer.h"
 #include "constants.h"
 
-inline const int get_axis_i(const int &axis, const int &a, const int &b, const int &c) {
+static inline const int get_axis_i(const int axis, const int a, const int b, const int c) {
   if (axis == 0) return b + (a * CS_P) + (c * CS_P2);
   else if (axis == 1) return a + (c * CS_P) + (b* CS_P2);
   else return c + (b * CS_P) + (a * CS_P2);
 }
 
 // Add checks to this function to skip culling against grass for example
-inline const bool solid_check(int voxel) {
+static inline const bool solid_check(int voxel) {
   return voxel > 0;
 }
 
-inline constexpr glm::ivec2 ao_dirs[8] = {
+static const glm::ivec2 ao_dirs[8] = {
   glm::ivec2(-1, 0),
    glm::ivec2(0, -1),
    glm::ivec2(0, 1),
@@ -56,11 +54,11 @@ inline constexpr glm::ivec2 ao_dirs[8] = {
    glm::ivec2(1, 1),
 };
 
-inline const int vertexAO(uint8_t& side1, uint8_t& side2, uint8_t& corner) {
+static inline const int vertexAO(uint8_t side1, uint8_t side2, uint8_t corner) {
   return (side1 && side2) ? 0 : (3 - (side1 + side2 + corner));
 }
 
-inline const bool compare_ao(std::vector<uint8_t>& voxels, int& axis, int& forward, int& right, int c, int forward_offset, int right_offset) {
+static inline const bool compare_ao(const std::vector<uint8_t>& voxels, int axis, int forward, int right, int c, int forward_offset, int right_offset) {
   for (auto& ao_dir : ao_dirs) {
     if (solid_check(voxels[get_axis_i(axis, right + ao_dir[0], forward + ao_dir[1], c)]) !=
       solid_check(voxels[get_axis_i(axis, right + right_offset + ao_dir[0], forward + forward_offset + ao_dir[1], c)])
@@ -71,7 +69,7 @@ inline const bool compare_ao(std::vector<uint8_t>& voxels, int& axis, int& forwa
   return true;
 }
 
-inline const void insert_quad(std::vector<uint32_t>& vertices, uint32_t& v1, uint32_t& v2, uint32_t& v3, uint32_t& v4, bool flipped, int& vertexI, int& maxVertices) {
+static inline const void insert_quad(std::vector<uint32_t>& vertices, uint32_t v1, uint32_t v2, uint32_t v3, uint32_t v4, bool flipped, int& vertexI, int& maxVertices) {
   if (vertexI >= maxVertices - 6) {
     vertices.resize(maxVertices * 2, 0);
     maxVertices *= 2;
@@ -97,12 +95,12 @@ inline const void insert_quad(std::vector<uint32_t>& vertices, uint32_t& v1, uin
   vertexI += 6;
 }
 
-inline const uint32_t get_vertex(uint32_t x, uint32_t y, uint32_t z, uint32_t type, uint32_t norm, uint32_t ao) {
+static inline const uint32_t get_vertex(uint32_t x, uint32_t y, uint32_t z, uint32_t type, uint32_t norm, uint32_t ao) {
   return (ao << 29) | (norm << 26) | (type << 18) | ((z - 1) << 12) | ((y - 1) << 6) | (x - 1);
 }
 
-static const uint64_t CULL_MASK = (1ULL << CS_P - 1);
-static const uint64_t BORDER_MASK = (1ULL | (1ULL <<  CS_P - 1));
+static const uint64_t CULL_MASK = (1ULL << (CS_P - 1));
+static const uint64_t BORDER_MASK = (1ULL | (1ULL <<  (CS_P - 1)));
 
 struct MeshData {
   std::vector<uint64_t>* col_face_masks = nullptr; // CS_P2 * 6
@@ -119,7 +117,7 @@ struct MeshData {
 // voxels - 64^3 (includes neighboring voxels)
 // vertices - pre-allocated array of vertices that will be poplulated. Can be re-used between runs and does not need to be clared.
 // vertexLength - output  number of vertices to read from vertices
-void mesh(std::vector<uint8_t>& voxels, MeshData& meshData, bool bake_ao) {
+void mesh(const std::vector<uint8_t>& voxels, MeshData& meshData, bool bake_ao) {
   meshData.vertexCount = 0;
   int vertexI = 0;
 
@@ -137,7 +135,7 @@ void mesh(std::vector<uint8_t>& voxels, MeshData& meshData, bool bake_ao) {
 
     for (int b = 0; b < CS_P; b++) {
       uint64_t cb = 0;
-      
+
       for (int c = 0; c < CS_P; c++) {
         if (solid_check(*p)) {
           a_axis_cols[b + (c * CS_P)] |= 1ULL << a;
@@ -317,6 +315,6 @@ void mesh(std::vector<uint8_t>& voxels, MeshData& meshData, bool bake_ao) {
   }
 
   meshData.vertexCount = vertexI + 1;
-};
+}
 
 #endif

--- a/src/mesher.h
+++ b/src/mesher.h
@@ -109,6 +109,14 @@ struct MeshData {
   std::vector<uint64_t>* merged_right = nullptr; // CS_P
   std::vector<uint64_t>* merged_forward = nullptr; // CS_P2
 
+  // Vertex data is packed into one unsigned integer:
+  // - x, y, z: 6 bit each (0-63)
+  // - Type: 8 bit (0-255)
+  // - Normal: 3 bit (0-5)
+  // - AO: 2 bit
+  //
+  // Meshes can be offset to world space using a per-draw uniform or by packing xyz
+  // in gl_BaseInstance if rendering with glMultiDrawArraysIndirect.
   std::vector<uint32_t>* vertices = nullptr;
   int vertexCount = 0;
   int maxVertices = 0;
@@ -117,6 +125,15 @@ struct MeshData {
 // voxels - 64^3 (includes neighboring voxels)
 // vertices - pre-allocated array of vertices that will be poplulated. Can be re-used between runs and does not need to be clared.
 // vertexLength - output  number of vertices to read from vertices
+//
+// @param[in] voxels The input data includes duplicate edge data from neighboring chunks which is used
+// for visibility culling and AO. For optimal performance, your world data should already be structured
+// this way so that you can feed the data straight into this algorithm.
+// Input data is ordered in YXZ and is 64^3 which results in a 62^3 mesh.
+//
+// @param[out] meshData The allocated vertices in MeshData with a length of meshData.vertexCount.
+//
+// @param[in] bake_ao true if you want baked ambient occlusion.
 void mesh(const std::vector<uint8_t>& voxels, MeshData& meshData, bool bake_ao) {
   meshData.vertexCount = 0;
   int vertexI = 0;


### PR DESCRIPTION
…functions

also removed constexpr from glm::ivec2 - when using glm with simd and less than c++20 one can't mix constexpr with simd

removed unused headers from mesher.h and move them into main.cpp